### PR TITLE
Add annotatioin `target.workload.openshift.io/management: '{"effect":"PreferredDuringScheduling"}'

### DIFF
--- a/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml
+++ b/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .Values.agentDeploymentName }}
   annotations:
   {{- with .Values.agentDeploymentAnnotations }}
-  {{ toYaml . | indent 8 }}
+  {{ toYaml . | indent 2 }}
   {{- end }}
 spec:
   replicas: {{ .Values.replicas }}
@@ -22,8 +22,9 @@ spec:
     metadata:
       annotations:
       {{- with .Values.agentDeploymentAnnotations }}
-      {{ toYaml . | indent 8 }}
+      {{ toYaml . | indent 2 }}
       {{- end }}
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         open-cluster-management.io/addon: cluster-proxy
         proxy.open-cluster-management.io/component-name: proxy-agent


### PR DESCRIPTION
In support of the workload partitioning feature (openshift/enhancements#703), we need to add annotations to all management pods and namespaces so they can be properly identified and assigned to segregated management cores on
clusters configured to do so.

Fixes: https://issues.redhat.com/browse/OCPBUGS-7652, https://issues.redhat.com/browse/OCPBUGS-11604

Related to: https://github.com/stolostron/cluster-proxy-addon/pull/98