### PR TITLE
Revert "move imagepullsecret to sa from deployment"

### DIFF
--- a/pkg/proxyagent/stolostronagent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml
+++ b/pkg/proxyagent/stolostronagent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml
@@ -157,3 +157,7 @@ spec:
         - name: service-proxy-server-cert
           secret:
             secretName: cluster-proxy-service-proxy-server-certificates
+      imagePullSecrets:
+      {{- range .Values.proxyAgentImagePullSecrets }}
+      - name: {{ . }}
+      {{- end }}

--- a/pkg/proxyagent/stolostronagent/manifests/charts/addon-agent/templates/service-account.yaml
+++ b/pkg/proxyagent/stolostronagent/manifests/charts/addon-agent/templates/service-account.yaml
@@ -3,7 +3,3 @@ kind: ServiceAccount
 metadata:
   namespace: {{ .Release.Namespace }}
   name: cluster-proxy
-imagePullSecrets:
- {{- range .Values.proxyAgentImagePullSecrets }}
-- name: {{ . }}
- {{- end }}


### PR DESCRIPTION
Reverts stolostron/cluster-proxy#87

lib-go will not update serviceaccount based on imagePullSecrets's changes.