### PR TITLE
fix(KONFLUX-3663): format PipelineRun files and upload SAST results

### DIFF
--- a/.tekton/cluster-proxy-mce-25-pull-request.yaml
+++ b/.tekton/cluster-proxy-mce-25-pull-request.yaml
@@ -305,7 +305,7 @@ spec:
               - "false"
       - name: sast-snyk-check
         runAfter:
-          - clone-repository
+          - build-container
         taskRef:
           params:
             - name: name
@@ -323,6 +323,11 @@ spec:
         workspaces:
           - name: workspace
             workspace: workspace
+        params:
+          - name: image-digest
+            value: $(tasks.build-container.results.IMAGE_DIGEST)
+          - name: image-url
+            value: $(tasks.build-container.results.IMAGE_URL)
       - name: clamav-scan
         params:
           - name: image-digest

--- a/.tekton/cluster-proxy-mce-25-push.yaml
+++ b/.tekton/cluster-proxy-mce-25-push.yaml
@@ -302,7 +302,7 @@ spec:
               - "false"
       - name: sast-snyk-check
         runAfter:
-          - clone-repository
+          - build-container
         taskRef:
           params:
             - name: name
@@ -320,6 +320,11 @@ spec:
         workspaces:
           - name: workspace
             workspace: workspace
+        params:
+          - name: image-digest
+            value: $(tasks.build-container.results.IMAGE_DIGEST)
+          - name: image-url
+            value: $(tasks.build-container.results.IMAGE_URL)
       - name: clamav-scan
         params:
           - name: image-digest

--- a/.tekton/cluster-proxy-plyk-pull-request.yaml
+++ b/.tekton/cluster-proxy-plyk-pull-request.yaml
@@ -287,8 +287,12 @@ spec:
         params:
           - name: SNYK_SECRET
             value: $(params.snyk-secret)
+          - name: image-digest
+            value: $(tasks.build-container.results.IMAGE_DIGEST)
+          - name: image-url
+            value: $(tasks.build-container.results.IMAGE_URL)
         runAfter:
-          - clone-repository
+          - build-container
         taskRef:
           bundle: quay.io/redhat-appstudio-tekton-catalog/task-sast-snyk-check:0.1@sha256:5aa816e7d7f5e03448d658edfeb26e086aa8a2102c4c3c1113651cf5ccfe55b1
           name: sast-snyk-check

--- a/.tekton/cluster-proxy-plyk-push.yaml
+++ b/.tekton/cluster-proxy-plyk-push.yaml
@@ -284,8 +284,12 @@ spec:
         params:
           - name: SNYK_SECRET
             value: $(params.snyk-secret)
+          - name: image-digest
+            value: $(tasks.build-container.results.IMAGE_DIGEST)
+          - name: image-url
+            value: $(tasks.build-container.results.IMAGE_URL)
         runAfter:
-          - clone-repository
+          - build-container
         taskRef:
           bundle: quay.io/redhat-appstudio-tekton-catalog/task-sast-snyk-check:0.1@sha256:5aa816e7d7f5e03448d658edfeb26e086aa8a2102c4c3c1113651cf5ccfe55b1
           name: sast-snyk-check


### PR DESCRIPTION
This update configures the SAST task to upload SARIF results to quay.io for
long-term storage

Related: 
- https://issues.redhat.com/browse/KONFLUX-3663
- https://issues.redhat.com/browse/KONFLUX-2263