### PR TITLE
Fix test errors: check the target service name in ut | update dockerfiles.

### DIFF
--- a/cmd/Dockerfile.rhtap
+++ b/cmd/Dockerfile.rhtap
@@ -19,7 +19,7 @@ ENV USER_UID=10001
 WORKDIR /
 COPY --from=builder /workspace/agent /workspace/manager ./
 
-RUN microdnf update && \
+RUN microdnf update -y && \
     microdnf clean all
 
 USER ${USER_UID}

--- a/cmd/pure.Dockerfile
+++ b/cmd/pure.Dockerfile
@@ -16,7 +16,7 @@ ENV USER_UID=10001
 WORKDIR /
 COPY --from=builder /workspace/agent /workspace/manager ./
 
-RUN microdnf update && \
+RUN microdnf update -y && \
     microdnf clean all
 
 USER ${USER_UID}

--- a/pkg/proxyagent/agent/agent_test.go
+++ b/pkg/proxyagent/agent/agent_test.go
@@ -699,7 +699,7 @@ func TestNewAgentAddon(t *testing.T) {
 			verifyManifests: func(t *testing.T, manifests []runtime.Object) {
 				assert.Len(t, manifests, len(expectedManifestNames))
 				assert.ElementsMatch(t, expectedManifestNames, manifestNames(manifests))
-				externalNameService := getKubeAPIServerExternalNameService(manifests)
+				externalNameService := getKubeAPIServerExternalNameService(manifests, clusterName)
 				assert.NotNil(t, externalNameService)
 				assert.Equal(t, "kubernetes.default.svc.test.com", externalNameService.Spec.ExternalName)
 			},
@@ -873,7 +873,7 @@ func TestNewAgentAddon(t *testing.T) {
 			verifyManifests: func(t *testing.T, manifests []runtime.Object) {
 				assert.Len(t, manifests, len(expectedManifestNames))
 				assert.ElementsMatch(t, expectedManifestNames, manifestNames(manifests))
-				externalNameService := getKubeAPIServerExternalNameService(manifests)
+				externalNameService := getKubeAPIServerExternalNameService(manifests, clusterName)
 				assert.NotNil(t, externalNameService)
 				assert.Equal(t, "kubernetes.default.svc.test.com", externalNameService.Spec.ExternalName)
 			},
@@ -920,7 +920,6 @@ func TestNewAgentAddon(t *testing.T) {
 				return
 			}
 			assert.NoError(t, err)
-
 			c.verifyManifests(t, manifests)
 		})
 	}
@@ -1218,11 +1217,14 @@ func getAgentDeployment(manifests []runtime.Object) *appsv1.Deployment {
 	return nil
 }
 
-func getKubeAPIServerExternalNameService(manifests []runtime.Object) *corev1.Service {
+func getKubeAPIServerExternalNameService(manifests []runtime.Object, clusterName string) *corev1.Service {
 	for _, manifest := range manifests {
 		switch obj := manifest.(type) {
 		case *corev1.Service:
-			return obj
+			// As the cluster-service.yaml shows, the service name is cluster name.
+			if obj.Name == clusterName {
+				return obj
+			}
 		}
 	}
 


### PR DESCRIPTION
After upgrade underlying implementation of helm render must use a map struct, so the order of the target service is not always the first one.

Before, we assume it render the manifests based on the order of the file names in the input.

---

Also, update the dockerfiles to assume yes in the process of microdnf update process.