### PR TITLE
Fix Konflux Dockerfile

### DIFF
--- a/cmd/Dockerfile.rhtap
+++ b/cmd/Dockerfile.rhtap
@@ -1,6 +1,6 @@
 # Build the manager binary
 # This dockerfile only used in middle stream build, without downloading and building APISERVER_NETWORK_PROXY_VERSION
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.22 as builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.22 as builder
 
 WORKDIR /workspace
 COPY . .


### PR DESCRIPTION
Building with CGO_ENABLED, the binary is incompatible with UBI8.
