### PR TITLE
Change to use pod internal connection between agent to service-proxy.

### DIFF
--- a/pkg/proxyagent/agent/agent.go
+++ b/pkg/proxyagent/agent/agent.go
@@ -290,6 +290,13 @@ func GetClusterProxyValueFunc(
 
 		var aids []string
 
+		// Add service-proxy host as the default agentIdentifier.
+		// Using SHA256 to hash cluster.name to:
+		// 1. Generate consistent and unique host names
+		// 2. Keep host name length under DNS limit (max 64 chars)
+		serviceProxyHost := fmt.Sprintf("cluster-%x", sha256.Sum256([]byte(cluster.Name)))[:64-len("cluster-")] + ".open-cluster-management.proxy"
+		aids = append(aids, fmt.Sprintf("host=%s", serviceProxyHost))
+
 		// add default kube-apiserver agentIdentifiers
 		if enableKubeApiProxy {
 			aids = append(aids, fmt.Sprintf("host=%s", cluster.Name))
@@ -324,6 +331,7 @@ func GetClusterProxyValueFunc(
 			"staticProxyAgentSecretKey":     keyDataBase64,
 			// support to access not only but also other services on managed cluster
 			"agentIdentifiers":   agentIdentifiers,
+			"serviceProxyHost":   serviceProxyHost,
 			"servicesToExpose":   servicesToExpose,
 			"enableKubeApiProxy": enableKubeApiProxy,
 		}, nil

--- a/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml
+++ b/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml
@@ -24,6 +24,10 @@ spec:
         open-cluster-management.io/addon: cluster-proxy
         proxy.open-cluster-management.io/component-name: proxy-agent
     spec:
+      hostAliases:
+      - ip: "127.0.0.1"
+        hostnames:
+        - {{ .Values.serviceProxyHost }}
       serviceAccount: cluster-proxy
       {{- if .Values.tolerations }}
       tolerations: {{ toYaml .Values.tolerations | nindent 8 }}


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/ACM-16801

`tls: failed to verify certificate: x509: certificate is valid for *, localhost, 127.0.0.1, not cluster-proxy-085552f3cfe64c5e2bac5d19b0033079e25ced90029637e5b`

The TLS certificate validation fails because the server's certificate SAN (Subject Alternative Name) doesn't match the requested hostname 'cluster-proxy-xxx', though it can be bypassed using InsecureSkipVerify on the client side.

Related:

https://github.com/stolostron/cluster-proxy-addon/blob/d8cdedcc7ea314018f88b9384853bbb3980c3483/pkg/controllers/certcontroller.go#L65

`*` used to match `cluster-proxy-085552f3cfe64c5e2bac5d19b0033079e25ced90029637e5b`.

Jira： https://issues.redhat.com/browse/ACM-16801

@haoqing0110 Provide the rca: https://github.com/golang/go/commit/375031d8dcec9ae74d2dbc437b201107dba3bb5f it's golang `verify` function changed.

Downstream upgrade builder image to: https://gitlab.cee.redhat.com/mce-cpaas-midstream/cluster-proxy-addon/-/blob/multicluster-engine-2.8-rhel-9/distgit/containers/cluster-proxy-addon/Dockerfile.in?ref_type=heads#L10