### PR TITLE
Add image-digest parameter to Tekton pipeline configurations for push…

### DIFF
--- a/.tekton/cluster-proxy-mce-29-pull-request.yaml
+++ b/.tekton/cluster-proxy-mce-29-pull-request.yaml
@@ -419,6 +419,8 @@ spec:
       params:
       - name: image-url
         value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: IMAGE
         value: $(params.output-image)
       - name: DOCKERFILE

--- a/.tekton/cluster-proxy-mce-29-push.yaml
+++ b/.tekton/cluster-proxy-mce-29-push.yaml
@@ -416,6 +416,8 @@ spec:
       params:
       - name: image-url
         value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: IMAGE
         value: $(params.output-image)
       - name: DOCKERFILE


### PR DESCRIPTION
… and pull requests.

Error:
```
Validation failed for pipelinerun cluster-proxy-mce-29-on-pull-request-cwbxp with error invalid input params for task sast-coverity-check-oci-ta: missing values for these params which have no default values: [image-digest]
```