### PR TITLE
chore: add configuration to disable indirect go module upgrades in Re…

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -33,6 +33,15 @@
             "enabled": false,
             "groupName": "go dependencies",
             "groupSlug": "go-deps"
+        },
+        {
+            "matchManagers": [
+                "gomod"
+            ],
+            "matchDepTypes": [
+                "indirect"
+            ],
+            "enabled": false
         }
     ],
     "rebaseWhen": "behind-base-branch",


### PR DESCRIPTION
…novate

This update introduces a new rule in the Renovate configuration to disable automatic upgrades for indirect dependencies managed by gomod.