### PR TITLE
Add multiarch build support to Tekton pipelines - Add support for lin…

### DIFF
--- a/.tekton/cluster-proxy-mce-29-pull-request.yaml
+++ b/.tekton/cluster-proxy-mce-29-pull-request.yaml
@@ -29,6 +29,9 @@ spec:
     - name: build-platforms
       value:
         - linux/x86_64
+        - linux/arm64
+        - linux/ppc64le
+        - linux/s390x
     - name: dockerfile
       value: cmd/Dockerfile.rhtap
     - name: path-context
@@ -109,6 +112,9 @@ spec:
         type: string
       - default:
           - linux/x86_64
+          - linux/arm64
+          - linux/ppc64le
+          - linux/s390x
         description: List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.
         name: build-platforms
         type: array

--- a/.tekton/cluster-proxy-mce-29-push.yaml
+++ b/.tekton/cluster-proxy-mce-29-push.yaml
@@ -26,6 +26,9 @@ spec:
     - name: build-platforms
       value:
         - linux/x86_64
+        - linux/arm64
+        - linux/ppc64le
+        - linux/s390x
     - name: dockerfile
       value: cmd/Dockerfile.rhtap
     - name: path-context
@@ -106,6 +109,9 @@ spec:
         type: string
       - default:
           - linux/x86_64
+          - linux/arm64
+          - linux/ppc64le
+          - linux/s390x
         description: List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.
         name: build-platforms
         type: array

--- a/cmd/Dockerfile.rhtap
+++ b/cmd/Dockerfile.rhtap
@@ -6,8 +6,8 @@ WORKDIR /workspace
 COPY . .
 
 # Build addons
-RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -a -o agent cmd/addon-agent/main.go
-RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -a -o manager cmd/addon-manager/main.go
+RUN CGO_ENABLED=1 go build -a -o agent cmd/addon-agent/main.go
+RUN CGO_ENABLED=1 go build -a -o manager cmd/addon-manager/main.go
 
 # Use distroless as minimal base image to package the manager binary
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest


### PR DESCRIPTION
…ux/arm64, linux/ppc64le, and linux/s390x platforms - Update both pull request and push pipeline configurations - Enable multiarch container image builds for better platform coverage