### PR TITLE
Fix: name conflict in multiple hub case.

### DIFF
--- a/pkg/proxyagent/agent/agent_test.go
+++ b/pkg/proxyagent/agent/agent_test.go
@@ -467,8 +467,8 @@ func TestNewAgentAddon(t *testing.T) {
 		addOnName,                   // namespace
 		"cluster-proxy",             // service account
 		"cluster-proxy-service-proxy-server-certificates",
-		"cluster-proxy-addon-agent-impersonator", // clusterrole for impersonation
-		"cluster-proxy-addon-agent-impersonator", // clusterrolebinding for impersonation
+		"cluster-proxy-addon-agent-impersonator",                                       // clusterrole for impersonation
+		"cluster-proxy-addon-agent-impersonator:open-cluster-management-cluster-proxy", // clusterrolebinding for impersonation
 	}
 
 	expectedManifestNamesWithoutClusterService := []string{
@@ -479,8 +479,8 @@ func TestNewAgentAddon(t *testing.T) {
 		addOnName,                   // namespace
 		"cluster-proxy",             // service account
 		"cluster-proxy-service-proxy-server-certificates",
-		"cluster-proxy-addon-agent-impersonator", // clusterrole for impersonation
-		"cluster-proxy-addon-agent-impersonator", // clusterrolebinding for impersonation
+		"cluster-proxy-addon-agent-impersonator",                                       // clusterrole for impersonation
+		"cluster-proxy-addon-agent-impersonator:open-cluster-management-cluster-proxy", // clusterrolebinding for impersonation
 	}
 
 	cases := []struct {
@@ -821,6 +821,7 @@ func TestNewAgentAddon(t *testing.T) {
 				newexpectedManifestNames := []string{}
 				newexpectedManifestNames = append(newexpectedManifestNames, expectedManifestNames...)
 				newexpectedManifestNames[5] = "addon-test"
+				newexpectedManifestNames[9] = "cluster-proxy-addon-agent-impersonator:addon-test" // clusterrolebinding
 				assert.ElementsMatch(t, newexpectedManifestNames, manifestNames(manifests))
 			},
 		},

--- a/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-clusterrolebinding.yaml
+++ b/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-clusterrolebinding.yaml
@@ -1,7 +1,11 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+  {{- if eq .Release.Namespace "open-cluster-management-agent-addon" }}
   name: cluster-proxy-addon-agent-impersonator
+  {{- else }}
+  name: cluster-proxy-addon-agent-impersonator:{{ .Release.Namespace }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
Releated Code:
* [work-agent](https://github.com/stolostron/multicloud-operators-foundation/blob/a368879db6399aad1380d9cc7baa3f4a0a4198c2/pkg/addon/manifests/chart/templates/cluster_role_binding.yaml#L5-L9)
* [managed-serviceaccount](https://github.com/stolostron/managed-serviceaccount/blob/fd72e143f5ce0b4f5aaaa0e362b68dac2c2fdec3/charts/managed-serviceaccount/templates/addontemplate.yaml#L35)

Related Jira: https://issues.redhat.com/browse/ACM-21376 


For addons that need to run in mulitple hub case,  the clusterrolebinding(or anyother cluster-scope resource) should have the suffix in its name to avoid resource conflict.