### PR TITLE
Update pathInRepo to common_mce_2.6.yaml for backplane-2.6 branch

### DIFF
--- a/.tekton/cluster-proxy-mce-26-pull-request.yaml
+++ b/.tekton/cluster-proxy-mce-26-pull-request.yaml
@@ -38,7 +38,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/common.yaml
+        value: pipelines/common_mce_2.6.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-cluster-proxy-mce-26
   workspaces:

--- a/.tekton/cluster-proxy-mce-26-push.yaml
+++ b/.tekton/cluster-proxy-mce-26-push.yaml
@@ -35,7 +35,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/common.yaml
+        value: pipelines/common_mce_2.6.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-cluster-proxy-mce-26
   workspaces:


### PR DESCRIPTION
## Summary

Updated the pathInRepo values in the .tekton PipelineRun files to use the correct version-specific pipeline file for the backplane-2.6 branch.

### Changes Made
- Updated `.tekton/cluster-proxy-mce-26-pull-request.yaml` pathInRepo from `pipelines/common.yaml` to `pipelines/common_mce_2.6.yaml`
- Updated `.tekton/cluster-proxy-mce-26-push.yaml` pathInRepo from `pipelines/common.yaml` to `pipelines/common_mce_2.6.yaml`

This ensures that the Tekton pipelines reference the correct version-specific pipeline definition that matches the branch version (2.6).

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>