### PR TITLE
Update tekton pipeline pathInRepo to common_mce_2.7.yaml

### DIFF
--- a/.tekton/cluster-proxy-mce-27-pull-request.yaml
+++ b/.tekton/cluster-proxy-mce-27-pull-request.yaml
@@ -38,7 +38,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/common.yaml
+        value: pipelines/common_mce_2.7.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-cluster-proxy-mce-27
   workspaces:

--- a/.tekton/cluster-proxy-mce-27-push.yaml
+++ b/.tekton/cluster-proxy-mce-27-push.yaml
@@ -35,7 +35,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/common.yaml
+        value: pipelines/common_mce_2.7.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-cluster-proxy-mce-27
   workspaces:


### PR DESCRIPTION
## Summary
- Updated pathInRepo values in .tekton directory PipelineRun files
- Changed from `pipelines/common.yaml` to `pipelines/common_mce_2.7.yaml` to match backplane-2.7 branch version
- Fixed both pull-request and push pipeline files

## Test plan
- Verify tekton pipelines can resolve the correct pipeline path
- Ensure CI/CD builds work correctly with the updated pipeline reference

🤖 Generated with [Claude Code](https://claude.ai/code)