### PR TITLE
Update Tekton pathInRepo for backplane-2.8 branch

### DIFF
--- a/.tekton/cluster-proxy-mce-28-pull-request.yaml
+++ b/.tekton/cluster-proxy-mce-28-pull-request.yaml
@@ -43,7 +43,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/common.yaml
+        value: pipelines/common_mce_2.8.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-cluster-proxy-mce-28
   workspaces:

--- a/.tekton/cluster-proxy-mce-28-push.yaml
+++ b/.tekton/cluster-proxy-mce-28-push.yaml
@@ -40,7 +40,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/common.yaml
+        value: pipelines/common_mce_2.8.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-cluster-proxy-mce-28
   workspaces:


### PR DESCRIPTION
## Summary

• Updated pathInRepo values in .tekton directory from `pipelines/common.yaml` to `pipelines/common_mce_2.8.yaml`
• Aligns pathInRepo value with branch version (backplane-2.8 → 2.8)
• Ensures Tekton pipelines use correct version-specific pipeline definitions

## Files Modified

- `.tekton/cluster-proxy-mce-28-pull-request.yaml`
- `.tekton/cluster-proxy-mce-28-push.yaml`

## Test plan

- [x] Verified pathInRepo values match the expected pattern for branch version
- [x] Checked that file syntax remains valid
- [ ] CI pipeline validation will confirm correct pipeline reference resolution

🤖 Generated with [Claude Code](https://claude.ai/code)