### PR TITLE
Update pathInRepo to common_mce_2.9.yaml for backplane-2.9

### DIFF
--- a/.tekton/cluster-proxy-mce-29-pull-request.yaml
+++ b/.tekton/cluster-proxy-mce-29-pull-request.yaml
@@ -44,7 +44,7 @@ spec:
     - name: revision
       value: main
     - name: pathInRepo
-      value: pipelines/common.yaml
+      value: pipelines/common_mce_2.9.yaml
   taskRunTemplate: {}
   workspaces:
   - name: git-auth

--- a/.tekton/cluster-proxy-mce-29-push.yaml
+++ b/.tekton/cluster-proxy-mce-29-push.yaml
@@ -41,7 +41,7 @@ spec:
     - name: revision
       value: main
     - name: pathInRepo
-      value: pipelines/common.yaml
+      value: pipelines/common_mce_2.9.yaml
   taskRunTemplate: {}
   workspaces:
   - name: git-auth


### PR DESCRIPTION
## Summary

This PR updates the `pathInRepo` values in the Tekton PipelineRun files to use `pipelines/common_mce_2.9.yaml` instead of `pipelines/common.yaml` to match the backplane-2.9 branch version.

## Changes

- Updated `.tekton/cluster-proxy-mce-29-pull-request.yaml`
- Updated `.tekton/cluster-proxy-mce-29-push.yaml`

Both files now reference `pipelines/common_mce_2.9.yaml` in the `pathInRepo` parameter, aligning with the backplane-2.9 branch naming convention.

## Test plan

- [x] Verified the pathInRepo values are correctly updated
- [x] Ensured both pull request and push pipeline files are consistent

🤖 Generated with [Claude Code](https://claude.ai/code)