### PR TITLE
Fix tekton pipeline pathInRepo for backplane-2.10 branch

### DIFF
--- a/.tekton/cluster-proxy-mce-210-pull-request.yaml
+++ b/.tekton/cluster-proxy-mce-210-pull-request.yaml
@@ -44,7 +44,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/common.yaml
+        value: pipelines/common_mce_2.10.yaml
   taskRunTemplate: {}
   workspaces:
     - name: git-auth


### PR DESCRIPTION
## Summary

- Updated pathInRepo value in cluster-proxy-mce-210-pull-request.yaml to use `pipelines/common_mce_2.10.yaml` instead of `pipelines/common.yaml`
- This ensures the pipeline references match the branch version (2.10) as required
- The push pipeline file was already correctly configured

## Test plan

- [x] Verified the pathInRepo value now matches the expected pattern `pipelines/common_mce_2.x.yaml`
- [x] Confirmed the push pipeline file already has the correct reference
- [x] No functional changes to pipeline logic, only correcting the reference path

🤖 Generated with [Claude Code](https://claude.ai/code)