### PR TITLE
Fix konflux build for mce-2.7

### DIFF
--- a/.tekton/cluster-proxy-mce-27-pull-request.yaml
+++ b/.tekton/cluster-proxy-mce-27-pull-request.yaml
@@ -26,6 +26,12 @@ spec:
     value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/release-mce-27/cluster-proxy-mce-27:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
+  - name: build-platforms
+    value:
+      - linux/x86_64
+      - linux/arm64
+      - linux/ppc64le
+      - linux/s390x
   - name: dockerfile
     value: cmd/Dockerfile.rhtap
   - name: path-context

--- a/.tekton/cluster-proxy-mce-27-push.yaml
+++ b/.tekton/cluster-proxy-mce-27-push.yaml
@@ -17,16 +17,28 @@ metadata:
   namespace: crt-redhat-acm-tenant
 spec:
   params:
-  - name: git-url
-    value: '{{source_url}}'
-  - name: revision
-    value: '{{revision}}'
-  - name: output-image
-    value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/release-mce-27/cluster-proxy-mce-27:{{revision}}
-  - name: dockerfile
-    value: cmd/Dockerfile.rhtap
-  - name: path-context
-    value: .
+    - name: git-url
+      value: '{{source_url}}'
+    - name: revision
+      value: '{{revision}}'
+    - name: output-image
+      value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/release-mce-27/cluster-proxy-mce-27:{{revision}}
+    - name: build-platforms
+      value:
+        - linux/x86_64
+        - linux/arm64
+        - linux/ppc64le
+        - linux/s390x
+    - name: dockerfile
+      value: cmd/Dockerfile.rhtap
+    - name: path-context
+      value: .
+    - name: send-slack-notification
+      value: "true"
+    - name: konflux-application-name
+      value: "release-mce-27"
+    - name: slack-member-id
+      value: "U01TX25RJ3B"
   pipelineRef:
     resolver: git
     params:

--- a/cmd/Dockerfile.rhtap
+++ b/cmd/Dockerfile.rhtap
@@ -6,8 +6,8 @@ WORKDIR /workspace
 COPY . .
 
 # Build addons
-RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -a -o agent cmd/addon-agent/main.go
-RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -a -o manager cmd/addon-manager/main.go
+RUN CGO_ENABLED=1 go build -a -o agent cmd/addon-agent/main.go
+RUN CGO_ENABLED=1 go build -a -o manager cmd/addon-manager/main.go
 
 # Use distroless as minimal base image to package the manager binary
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest


### PR DESCRIPTION
## Summary
- Add multi-platform build support (x86_64, arm64, ppc64le, s390x) to Tekton pipelines
- Remove hardcoded GOOS/GOARCH from Dockerfile build commands to support multi-arch builds
- Add Slack notification parameters to push pipeline for better monitoring
- Format Tekton pipeline parameters consistently

## Changes Made
This PR applies the same fixes that were implemented in PR #426 for the mce-2.6 branch to ensure Konflux build compatibility for mce-2.7:

### Tekton Pipeline Updates
- **Pull Request Pipeline**: Added `build-platforms` parameter with multi-arch support
- **Push Pipeline**: Added `build-platforms` parameter, Slack notification configs, and reformatted parameters for consistency

### Dockerfile Improvements  
- Removed hardcoded `GOOS=linux GOARCH=amd64` from build commands
- Let Konflux handle platform-specific builds based on `build-platforms` parameter

## Test plan
- [ ] Verify Tekton pipelines trigger correctly on PR and push events
- [ ] Confirm multi-platform images are built successfully
- [ ] Test Slack notifications are sent for push events
- [ ] Validate all platforms (x86_64, arm64, ppc64le, s390x) build without errors

🤖 Generated with [Claude Code](https://claude.ai/code)