### PR TITLE
Fix tekton pathInRepo for main branch

### DIFF
--- a/.tekton/cluster-proxy-mce-210-pull-request.yaml
+++ b/.tekton/cluster-proxy-mce-210-pull-request.yaml
@@ -44,7 +44,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/common.yaml
+        value: pipelines/common_mce_2.main.yaml
   taskRunTemplate: {}
   workspaces:
     - name: git-auth

--- a/.tekton/cluster-proxy-mce-210-push.yaml
+++ b/.tekton/cluster-proxy-mce-210-push.yaml
@@ -47,7 +47,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/common_mce_2.10.yaml
+        value: pipelines/common_mce_2.main.yaml
   taskRunTemplate: {}
   workspaces:
     - name: git-auth


### PR DESCRIPTION
## Summary
- Updated pathInRepo values in PipelineRun files to use `pipelines/common_mce_2.main.yaml` for main branch
- Fixed `.tekton/cluster-proxy-mce-210-pull-request.yaml` to use correct pathInRepo format
- Fixed `.tekton/cluster-proxy-mce-210-push.yaml` to use correct pathInRepo for main branch

## Changes
- Changed `pipelines/common.yaml` → `pipelines/common_mce_2.main.yaml` in pull request pipeline
- Changed `pipelines/common_mce_2.10.yaml` → `pipelines/common_mce_2.main.yaml` in push pipeline

## Test plan
- [x] Verified pathInRepo format follows the pattern: `pipelines/common_mce_2.x.yaml` where x is the branch version
- [x] Confirmed main branch should use `2.main` suffix as specified in task requirements
- [x] Both PipelineRun files now reference the correct pipeline path

🤖 Generated with [Claude Code](https://claude.ai/code)