### PR TITLE
Fix pathInRepo for pull-request pipeline to use correct version

### DIFF
--- a/.tekton/cluster-proxy-mce-210-pull-request.yaml
+++ b/.tekton/cluster-proxy-mce-210-pull-request.yaml
@@ -44,7 +44,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/common.yaml
+        value: pipelines/common_mce_2.10.yaml
   taskRunTemplate: {}
   workspaces:
     - name: git-auth


### PR DESCRIPTION
## Summary

- Updated cluster-proxy-mce-210-pull-request.yaml to use `pipelines/common_mce_2.10.yaml` instead of `pipelines/common.yaml`
- This aligns with the requirement that main branch should use the 2.10 version path
- The push pipeline was already correctly configured

## Test plan

- [x] Verified that cluster-proxy-mce-210-push.yaml already uses correct path `pipelines/common_mce_2.10.yaml`
- [x] Updated cluster-proxy-mce-210-pull-request.yaml to match the same version
- [x] Confirmed both files now consistently reference the correct pipeline version for main branch

## Justification

According to the pipeline configuration requirements:
- Main branch should use `pipelines/common_mce_2.10.yaml`
- Release branches should use the corresponding version (e.g., `backplane-2.10` should use `pipelines/common_mce_2.10.yaml`)

This change ensures consistency between pull-request and push pipelines.