### PR TITLE
Update tekton dockerfile parameter for backplane-2.6

### DIFF
--- a/.tekton/cluster-proxy-mce-26-pull-request.yaml
+++ b/.tekton/cluster-proxy-mce-26-pull-request.yaml
@@ -33,7 +33,7 @@ spec:
       - linux/ppc64le
       - linux/s390x
   - name: dockerfile
-    value: cmd/Dockerfile.rhtap
+    value: Dockerfile.rhtap
   - name: path-context
     value: .
   pipelineRef:

--- a/.tekton/cluster-proxy-mce-26-push.yaml
+++ b/.tekton/cluster-proxy-mce-26-push.yaml
@@ -30,7 +30,7 @@ spec:
         - linux/ppc64le
         - linux/s390x
     - name: dockerfile
-      value: cmd/Dockerfile.rhtap
+      value: Dockerfile.rhtap
     - name: path-context
       value: .
     - name: send-slack-notification


### PR DESCRIPTION
## Summary
- Update dockerfile parameter from `cmd/Dockerfile.rhtap` to `Dockerfile.rhtap` in tekton pipeline files
- Fix both push and pull request pipeline configurations to align with required standards

## Changes
- Modified `.tekton/cluster-proxy-mce-26-push.yaml` dockerfile parameter
- Modified `.tekton/cluster-proxy-mce-26-pull-request.yaml` dockerfile parameter

## Test plan
- Verify tekton pipelines can find the correct Dockerfile.rhtap file
- Ensure build process works with updated configuration

🤖 Generated with [Claude Code](https://claude.ai/code)