### PR TITLE
Fix dockerfile path in tekton pipeline configurations

### DIFF
--- a/.tekton/cluster-proxy-mce-27-pull-request.yaml
+++ b/.tekton/cluster-proxy-mce-27-pull-request.yaml
@@ -33,7 +33,7 @@ spec:
       - linux/ppc64le
       - linux/s390x
   - name: dockerfile
-    value: cmd/Dockerfile.rhtap
+    value: Dockerfile.rhtap
   - name: path-context
     value: .
   pipelineRef:

--- a/.tekton/cluster-proxy-mce-27-push.yaml
+++ b/.tekton/cluster-proxy-mce-27-push.yaml
@@ -30,7 +30,7 @@ spec:
         - linux/ppc64le
         - linux/s390x
     - name: dockerfile
-      value: cmd/Dockerfile.rhtap
+      value: Dockerfile.rhtap
     - name: path-context
       value: .
     - name: send-slack-notification


### PR DESCRIPTION
## Summary
- Updated dockerfile parameter from `cmd/Dockerfile.rhtap` to `Dockerfile.rhtap` in both push and pull-request pipeline configurations
- This change aligns the tekton configurations with the required task specifications
- Affects both cluster-proxy-mce-27-push.yaml and cluster-proxy-mce-27-pull-request.yaml files

## Test plan
- [x] Verified that all other required parameters are already present in both files
- [x] Confirmed that build-platforms include all required architectures
- [x] Validated that konflux-application-name is correctly set to "release-mce-27" for the 2.7 branch

This is a configuration update that standardizes the dockerfile path parameter across tekton pipeline configurations.