### PR TITLE
Add missing Tekton pipeline parameters for cluster-proxy-mce-29

### DIFF
--- a/.tekton/cluster-proxy-mce-29-push.yaml
+++ b/.tekton/cluster-proxy-mce-29-push.yaml
@@ -33,6 +33,12 @@ spec:
     value: cmd/Dockerfile.rhtap
   - name: path-context
     value: .
+  - name: send-slack-notification
+    value: "true"
+  - name: konflux-application-name
+    value: "release-mce-29"
+  - name: slack-member-id
+    value: "U01TX25RJ3B"
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
## Summary
- Add missing send-slack-notification parameter set to true
- Add missing konflux-application-name parameter set to release-mce-29  
- Add missing slack-member-id parameter set to U01TX25RJ3B

## Description
This PR updates the cluster-proxy-mce-29-push.yaml pipeline file to include required parameters:
- `send-slack-notification`: "true"
- `konflux-application-name`: "release-mce-29" (following backplane-2.9 naming convention)
- `slack-member-id`: "U01TX25RJ3B"

The pull-request.yaml file already contains the required build-platforms parameter and needs no changes.

## Test plan
- [x] Verified all required parameters are added to push.yaml
- [x] Verified pull-request.yaml already has required build-platforms
- [x] Confirmed konflux-application-name follows branch naming convention (2.9 -> 29)

🤖 Generated with [Claude Code](https://claude.ai/code)