### PR TITLE
Remove GOOS and GOARCH flags from Dockerfile.rhtap

### DIFF
--- a/cmd/Dockerfile.rhtap
+++ b/cmd/Dockerfile.rhtap
@@ -6,8 +6,8 @@ WORKDIR /workspace
 COPY . .
 
 # Build addons
-RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -a -o agent cmd/addon-agent/main.go
-RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -a -o manager cmd/addon-manager/main.go
+RUN CGO_ENABLED=1 go build -a -o agent cmd/addon-agent/main.go
+RUN CGO_ENABLED=1 go build -a -o manager cmd/addon-manager/main.go
 
 # Use distroless as minimal base image to package the manager binary
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest


### PR DESCRIPTION
## Summary

- Removed `GOOS=linux GOARCH=amd64` flags from build commands in cmd/Dockerfile.rhtap
- This allows the build to use the default GOOS and GOARCH values for the target platform

## Changes

- Updated RUN commands for building agent and manager binaries to remove explicit platform specification
- This change ensures cross-platform compatibility during the build process

## Testing

- [x] Verified that the syntax is correct
- [x] Confirmed the change aligns with the project requirements

🤖 Generated with [Claude Code](https://claude.ai/code)