### PR TITLE
fix: correct livenessProbe typo in addon-agent deployment

### DIFF
--- a/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml
+++ b/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml
@@ -154,7 +154,7 @@ spec:
             - --cert=/server-cert/tls.crt
             - --key=/server-cert/tls.key
             - --hub-kubeconfig=/etc/kubeconfig/kubeconfig
-          livesnessProbe:
+          livenessProbe:
             httpGet:
               path: /healthz
               port: 8000


### PR DESCRIPTION
Fix typo in livesnessProbe field name to livenessProbe in the addon-agent deployment template. This ensures the health check probe is properly configured for the proxy agent container.

Fix customer issue: https://access.redhat.com/support/cases/#/case/04242920