### PR TITLE
Fix typo: change livesnessProbe to livenessProbe in addon-agent deployment

### DIFF
--- a/pkg/proxyagent/stolostronagent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml
+++ b/pkg/proxyagent/stolostronagent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml
@@ -129,7 +129,7 @@ spec:
             - --ocpservice-ca=/ocpservice-ca/service-ca.crt
             - --cert=/server-cert/tls.crt
             - --key=/server-cert/tls.key
-          livesnessProbe:
+          livenessProbe:
             httpGet:
               path: /healthz
               port: 8000


### PR DESCRIPTION
## Summary

This PR fixes a typo in the addon-agent deployment template where `livesnessProbe` was incorrectly spelled instead of `livenessProbe`.

## Changes

- Fixed typo in `pkg/proxyagent/stolostronagent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml`
- Changed `livesnessProbe` to `livenessProbe` on line 132

## Rationale

The correct Kubernetes field name is `livenessProbe`, not `livesnessProbe`. This typo would prevent the liveness probe from functioning correctly in the deployment.

## Testing

- Verified the change fixes the typo
- No functional testing required as this is a simple typo fix