### PR TITLE
Fix typo: change livesnessProbe to livenessProbe in addon-agent deployment

### DIFF
--- a/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml
+++ b/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml
@@ -129,7 +129,7 @@ spec:
             - --ocpservice-ca=/ocpservice-ca/service-ca.crt
             - --cert=/server-cert/tls.crt
             - --key=/server-cert/tls.key
-          livesnessProbe:
+          livenessProbe:
             httpGet:
               path: /healthz
               port: 8000


### PR DESCRIPTION
## Summary

Fixed a typo in the addon-agent deployment template where `livesnessProbe` was incorrectly spelled instead of `livenessProbe`.

## Changes
- Fixed typo in `pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml`
- Changed `livesnessProbe` to `livenessProbe` on line 132

## Impact
This ensures the Kubernetes liveness probe is properly configured with the correct field name.