### PR TITLE
Fix typo: change livesnessProbe to livenessProbe in addon-agent deployment

### DIFF
--- a/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml
+++ b/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml
@@ -154,7 +154,7 @@ spec:
             - --cert=/server-cert/tls.crt
             - --key=/server-cert/tls.key
             - --hub-kubeconfig=/etc/kubeconfig/kubeconfig
-          livesnessProbe:
+          livenessProbe:
             httpGet:
               path: /healthz
               port: 8000


### PR DESCRIPTION
## Summary

This PR fixes a typo in the addon-agent deployment template where `livesnessProbe` should be `livenessProbe`.

## Changes

- Fixed typo in `pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml`
- Changed `livesnessProbe` to `livenessProbe` on line 157

## Motivation

This is a simple typo fix to ensure the Kubernetes liveness probe is correctly named and functional. The incorrect spelling `livesnessProbe` would prevent the liveness probe from working properly.

## Testing

- [x] Verified no other instances of the typo exist in the codebase
- [x] Confirmed the change maintains proper YAML formatting