### PR TITLE
Fix typo: change livesnessProbe to livenessProbe in addon-agent deployment

### DIFF
--- a/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml
+++ b/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml
@@ -129,7 +129,7 @@ spec:
             - --ocpservice-ca=/ocpservice-ca/service-ca.crt
             - --cert=/server-cert/tls.crt
             - --key=/server-cert/tls.key
-          livesnessProbe:
+          livenessProbe:
             httpGet:
               path: /healthz
               port: 8000


### PR DESCRIPTION
## Summary

Fixed a typo in the addon-agent deployment template where `livesnessProbe` was incorrectly spelled instead of `livenessProbe`.

## Changes
- Updated `pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml` line 132
- Changed `livesnessProbe:` to `livenessProbe:`

## Impact
- This fix ensures the Kubernetes deployment YAML is valid
- The liveness probe will now be properly recognized by Kubernetes

## Testing
- Verified the change is syntactically correct
- No functional changes, only spelling correction