### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for cluster-proxy-mce-29

### DIFF
--- a/cmd/Dockerfile.rhtap
+++ b/cmd/Dockerfile.rhtap
@@ -14,7 +14,8 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 ENV USER_UID=10001
 
 LABEL \
-    name="cluster-proxy" \
+    name="multicluster-engine/cluster-proxy-rhel9" \
+    cpe="cpe:/a:redhat:multicluster_engine:2.9::el9" \
     com.redhat.component="cluster-proxy" \
     description="A pluggable addon for OCM that enables proxy tunnels between hub and managed clusters using apiserver-network-proxy" \
     io.k8s.description="Cluster Proxy automates the installation of apiserver-network-proxy on both hub cluster and managed clusters, establishing reverse proxy tunnels to enable cross-VPC service access" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
