### PR TITLE
Add FIPS build flags to Dockerfile

### DIFF
--- a/cmd/Dockerfile.rhtap
+++ b/cmd/Dockerfile.rhtap
@@ -8,13 +8,13 @@ COPY . .
 # Build apiserver-network-proxy binaries from git submodule (third_party/apiserver-network-proxy)
 # The submodule is at version v0.1.6-patch-03 from https://github.com/stolostron/apiserver-network-proxy
 RUN cd third_party/apiserver-network-proxy && \
-    CGO_ENABLED=1 go build -o proxy-agent cmd/agent/main.go && \
-    CGO_ENABLED=1 go build -o proxy-server cmd/server/main.go
+    CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime go build -o proxy-agent cmd/agent/main.go && \
+    CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime go build -o proxy-server cmd/server/main.go
 
 # Build addons
-RUN CGO_ENABLED=1 go build -a -o agent cmd/addon-agent/main.go
-RUN CGO_ENABLED=1 go build -a -o manager cmd/addon-manager/main.go
-RUN CGO_ENABLED=1 go build -a -o cluster-proxy cmd/cluster-proxy/main.go
+RUN CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime go build -a -o agent cmd/addon-agent/main.go
+RUN CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime go build -a -o manager cmd/addon-manager/main.go
+RUN CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime go build -a -o cluster-proxy cmd/cluster-proxy/main.go
 
 # Use distroless as minimal base image to package the manager binary
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest


### PR DESCRIPTION
## Summary
- Add `GOEXPERIMENT=strictfipsruntime` to 5 `go build` commands in `cmd/Dockerfile.rhtap` for FIPS compliance

JIRA: HYPBLD-844

Made with [Cursor](https://cursor.com)