### PR TITLE
:bug: reuse http.Transport per cluster in user-server to reduce tunnel churn

### DIFF
--- a/pkg/userserver/user_server.go
+++ b/pkg/userserver/user_server.go
@@ -11,13 +11,16 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
 	grpccredentials "google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
+	"k8s.io/apimachinery/pkg/util/httpstream"
 	"k8s.io/klog/v2"
+
 	addonutils "open-cluster-management.io/addon-framework/pkg/utils"
 	"open-cluster-management.io/cluster-proxy/pkg/constant"
 	clusterproxyutil "open-cluster-management.io/cluster-proxy/pkg/util"
@@ -52,7 +55,6 @@ var (
 )
 
 type userServer struct {
-	// TODO: make it a controller and reuse tunnel for each cluster to improve performance.
 	getTunnel       func(context.Context) (konnectivity.Tunnel, error)
 	proxyServerHost string
 	proxyServerPort int
@@ -66,6 +68,13 @@ type userServer struct {
 	agentInstallNamespace  string
 
 	addonLister addonlisterv1alpha1.ManagedClusterAddOnLister
+
+	// transports caches one http.Transport per managed cluster name.
+	// Each transport maintains a connection pool to the cluster's service-proxy,
+	// allowing tunnel reuse across sequential HTTP requests and eliminating the
+	// tunnel-per-request churn that saturates the ANP proxy-server under load.
+	// Key: cluster name (string), Value: *http.Transport
+	transports sync.Map
 }
 
 func (k *userServer) AddFlags(cmd *cobra.Command) {
@@ -155,6 +164,66 @@ func (k *userServer) init(ctx context.Context) error {
 	return nil
 }
 
+// getOrCreateTransport returns a cached *http.Transport for the given cluster,
+// creating one if it does not already exist.
+//
+// The key mechanism is Go's http.Transport connection pooling. After a request
+// completes, the transport retains the underlying net.Conn in its idle pool
+// rather than closing it. Because the net.Conn IS the konnectivity tunnel (the
+// connection established by DialContext through the ANP proxy-server), keeping
+// the connection alive keeps the tunnel -- and the Proxy() gRPC stream on the
+// proxy-server -- alive between requests. Subsequent requests to the same
+// cluster reuse the idle connection without invoking DialContext at all: no new
+// tunnel, no new gRPC stream, no additional Proxy() handler on the proxy-server.
+//
+// DialContext is therefore only called on a pool miss: the first request to a
+// cluster, after IdleConnTimeout (90s) elapses with no activity, or when
+// concurrent requests exhaust the pool (up to MaxIdleConnsPerHost connections
+// are retained). At high request rates, multiple connections may exist
+// simultaneously, but each is reused by subsequent requests rather than torn
+// down after a single use.
+//
+// Without this caching, every HTTP request creates a new gRPC tunnel (full
+// TCP+TLS+HTTP/2 negotiation) regardless of whether an existing tunnel is idle.
+// Under load this saturates the ANP proxy-server with concurrent short-lived
+// Proxy() handlers, causing lock contention on shared state and channel
+// backpressure errors.
+func (k *userServer) getOrCreateTransport(clusterName string) *http.Transport {
+	if t, ok := k.transports.Load(clusterName); ok {
+		return t.(*http.Transport)
+	}
+
+	transport := &http.Transport{
+		MaxIdleConns:        100, // really MaxIdleConnsPerHost is the limit since this transport is for 1 host (managed cluster) only.
+		MaxIdleConnsPerHost: 10,
+		IdleConnTimeout:     90 * time.Second,
+		TLSHandshakeTimeout: 10 * time.Second,
+		// Not using our global TLSConfig for outbound will rely on server settings
+		TLSClientConfig: &tls.Config{
+			RootCAs:    serviceProxyRootCA,
+			MinVersion: tls.VersionTLS12,
+		},
+		// golang http pkg automatically upgrade http connection to http2 connection, but http2 can not upgrade to SPDY which used in "kubectl exec".
+		// set ForceAttemptHTTP2 = false to prevent auto http2 upgration
+		ForceAttemptHTTP2:     false,
+		ExpectContinueTimeout: 1 * time.Second,
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			klog.V(4).Infof("creating tunnel for cluster %s (transport pool miss)", clusterName)
+			tunnel, err := k.getTunnel(ctx)
+			if err != nil {
+				return nil, err
+			}
+			return tunnel.DialContext(ctx, network, addr)
+		},
+	}
+
+	// LoadOrStore handles the race where two goroutines concurrently create
+	// a transport for the same cluster -- the loser's transport is discarded
+	// (it has no active connections so there is no resource leak).
+	actual, _ := k.transports.LoadOrStore(clusterName, transport)
+	return actual.(*http.Transport)
+}
+
 func (k *userServer) ServeHTTP(wr http.ResponseWriter, req *http.Request) {
 	if klog.V(4).Enabled() {
 		dump, err := httputil.DumpRequest(req, true)
@@ -185,31 +254,48 @@ func (k *userServer) ServeHTTP(wr http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	tunnel, err := k.getTunnel(req.Context())
-	if err != nil {
-		http.Error(wr, err.Error(), http.StatusBadRequest)
-		return
+	// Upgrade requests (SPDY/WebSocket, e.g. kubectl exec terminal sessions) are
+	// long-lived and need a dedicated tunnel for their duration. They bypass the
+	// shared transport cache and get the current single-use tunnel behavior.
+	//
+	// REST API requests use the cached transport. Go's http.Transport retains
+	// the net.Conn (the konnectivity tunnel) in its idle pool after each request
+	// completes, so DialContext -- which creates a new gRPC tunnel -- is only
+	// called on a pool miss. Sequential requests to the same cluster reuse the
+	// idle connection and the existing Proxy() stream on the proxy-server,
+	// avoiding the per-request tunnel churn that causes proxy-server saturation.
+	var transport http.RoundTripper
+	if httpstream.IsUpgradeRequest(req) {
+		klog.V(4).Infof("upgrade request for cluster %s, using dedicated tunnel", tsc.Cluster)
+		tunnel, err := k.getTunnel(req.Context())
+		if err != nil {
+			http.Error(wr, err.Error(), http.StatusBadRequest)
+			return
+		}
+		transport = &http.Transport{
+			MaxIdleConns:          100,
+			IdleConnTimeout:       90 * time.Second,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
+			// Not using our global TLSConfig for outbound will rely on server settings
+			TLSClientConfig: &tls.Config{
+				RootCAs:    serviceProxyRootCA,
+				MinVersion: tls.VersionTLS12,
+			},
+			// golang http pkg automatically upgrade http connection to http2 connection, but http2 can not upgrade to SPDY which used in "kubectl exec".
+			// set ForceAttemptHTTP2 = false to prevent auto http2 upgration
+			ForceAttemptHTTP2: false,
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				klog.V(4).Infof("proxy dial to %s (upgrade request)", addr)
+				return tunnel.DialContext(ctx, network, addr)
+			},
+		}
+	} else {
+		transport = k.getOrCreateTransport(tsc.Cluster)
 	}
 
 	proxy := httputil.NewSingleHostReverseProxy(targetURL)
-	proxy.Transport = &http.Transport{
-		MaxIdleConns:          100,
-		IdleConnTimeout:       90 * time.Second,
-		TLSHandshakeTimeout:   10 * time.Second,
-		ExpectContinueTimeout: 1 * time.Second,
-		TLSClientConfig: &tls.Config{
-			RootCAs:    serviceProxyRootCA,
-			MinVersion: tls.VersionTLS12,
-		},
-		// golang http pkg automaticly upgrade http connection to http2 connection, but http2 can not upgrade to SPDY which used in "kubectl exec".
-		// set ForceAttemptHTTP2 = false to prevent auto http2 upgration
-		ForceAttemptHTTP2: false,
-		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-			klog.V(4).Infof("proxy dial to %s", addr)
-			// TODO: may find a way to cache the proxyConn.
-			return tunnel.DialContext(ctx, network, addr)
-		},
-	}
+	proxy.Transport = transport
 
 	proxy.ErrorHandler = func(rw http.ResponseWriter, r *http.Request, e error) {
 		http.Error(rw, fmt.Sprintf("proxy to anp-proxy-server failed because %v", e), http.StatusBadGateway)

--- a/pkg/userserver/user_server_test.go
+++ b/pkg/userserver/user_server_test.go
@@ -1,0 +1,305 @@
+package userserver
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	konnectivity "sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client"
+)
+
+// fakeConn is a minimal net.Conn that satisfies the interface for tests.
+type fakeConn struct{}
+
+func (f *fakeConn) Read(b []byte) (int, error)         { return 0, io.EOF }
+func (f *fakeConn) Write(b []byte) (int, error)        { return len(b), nil }
+func (f *fakeConn) Close() error                       { return nil }
+func (f *fakeConn) LocalAddr() net.Addr                { return &net.TCPAddr{} }
+func (f *fakeConn) RemoteAddr() net.Addr               { return &net.TCPAddr{} }
+func (f *fakeConn) SetDeadline(t time.Time) error      { return nil }
+func (f *fakeConn) SetReadDeadline(t time.Time) error  { return nil }
+func (f *fakeConn) SetWriteDeadline(t time.Time) error { return nil }
+
+var _ net.Conn = (*fakeConn)(nil)
+
+// fakeTunnel implements konnectivity.Tunnel and counts DialContext calls.
+type fakeTunnel struct {
+	dialCount int64
+	done      chan struct{}
+}
+
+func newFakeTunnel() *fakeTunnel {
+	t := &fakeTunnel{done: make(chan struct{})}
+	close(t.done)
+	return t
+}
+
+func (f *fakeTunnel) DialContext(_ context.Context, _, _ string) (net.Conn, error) {
+	atomic.AddInt64(&f.dialCount, 1)
+	return &fakeConn{}, nil
+}
+
+func (f *fakeTunnel) Done() <-chan struct{} { return f.done }
+
+var _ konnectivity.Tunnel = (*fakeTunnel)(nil)
+
+// dialingFakeTunnel dials a real TCP address, for tests that need ServeHTTP to
+// complete an actual HTTP round-trip.
+type dialingFakeTunnel struct {
+	addr string
+	done chan struct{}
+}
+
+func newDialingFakeTunnel(addr string) *dialingFakeTunnel {
+	t := &dialingFakeTunnel{addr: addr, done: make(chan struct{})}
+	close(t.done)
+	return t
+}
+
+func (d *dialingFakeTunnel) DialContext(ctx context.Context, network, _ string) (net.Conn, error) {
+	return (&net.Dialer{}).DialContext(ctx, network, d.addr)
+}
+
+func (d *dialingFakeTunnel) Done() <-chan struct{} { return d.done }
+
+var _ konnectivity.Tunnel = (*dialingFakeTunnel)(nil)
+
+// setupServiceProxyRootCA overrides the package-level serviceProxyRootCA for
+// the duration of a test and restores it on cleanup.
+func setupServiceProxyRootCA(t *testing.T, pool *x509.CertPool) {
+	t.Helper()
+	old := serviceProxyRootCA
+	serviceProxyRootCA = pool
+	t.Cleanup(func() { serviceProxyRootCA = old })
+}
+
+// --- getOrCreateTransport tests ---
+
+func TestGetOrCreateTransport_ReturnsSameTransportForSameCluster(t *testing.T) {
+	s := &userServer{}
+	s.getTunnel = func(_ context.Context) (konnectivity.Tunnel, error) {
+		return newFakeTunnel(), nil
+	}
+
+	t1 := s.getOrCreateTransport("cluster1")
+	t2 := s.getOrCreateTransport("cluster1")
+
+	if t1 != t2 {
+		t.Fatal("expected same *http.Transport for same cluster, got different pointers")
+	}
+}
+
+func TestGetOrCreateTransport_ReturnsDifferentTransportForDifferentClusters(t *testing.T) {
+	s := &userServer{}
+	s.getTunnel = func(_ context.Context) (konnectivity.Tunnel, error) {
+		return newFakeTunnel(), nil
+	}
+
+	ta := s.getOrCreateTransport("cluster-a")
+	tb := s.getOrCreateTransport("cluster-b")
+
+	if ta == tb {
+		t.Fatal("expected different *http.Transport for different clusters, got same pointer")
+	}
+}
+
+func TestGetOrCreateTransport_Settings(t *testing.T) {
+	s := &userServer{}
+	s.getTunnel = func(_ context.Context) (konnectivity.Tunnel, error) {
+		return newFakeTunnel(), nil
+	}
+
+	transport := s.getOrCreateTransport("cluster1")
+
+	if transport.MaxIdleConns != 100 {
+		t.Errorf("MaxIdleConns: got %d, want 100", transport.MaxIdleConns)
+	}
+	if transport.MaxIdleConnsPerHost != 10 {
+		t.Errorf("MaxIdleConnsPerHost: got %d, want 10", transport.MaxIdleConnsPerHost)
+	}
+	if transport.IdleConnTimeout != 90*time.Second {
+		t.Errorf("IdleConnTimeout: got %v, want 90s", transport.IdleConnTimeout)
+	}
+	if transport.ForceAttemptHTTP2 {
+		t.Error("ForceAttemptHTTP2 must be false to allow SPDY upgrades")
+	}
+	if transport.TLSClientConfig == nil {
+		t.Fatal("TLSClientConfig must not be nil")
+	}
+	if transport.TLSClientConfig.MinVersion != tls.VersionTLS12 {
+		t.Errorf("TLS MinVersion: got %d, want %d (TLS 1.2)",
+			transport.TLSClientConfig.MinVersion, tls.VersionTLS12)
+	}
+}
+
+func TestGetOrCreateTransport_ConcurrentAccessReturnsSameTransport(t *testing.T) {
+	s := &userServer{}
+	s.getTunnel = func(_ context.Context) (konnectivity.Tunnel, error) {
+		return newFakeTunnel(), nil
+	}
+
+	const goroutines = 50
+	results := make([]*http.Transport, goroutines)
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			results[i] = s.getOrCreateTransport("cluster1")
+		}()
+	}
+	wg.Wait()
+
+	first := results[0]
+	for i, tr := range results {
+		if tr != first {
+			t.Errorf("goroutine %d got a different transport pointer", i)
+		}
+	}
+}
+
+func TestGetOrCreateTransport_DialContextCreatesNewTunnelOnPoolMiss(t *testing.T) {
+	var tunnelCount int64
+	s := &userServer{}
+	s.getTunnel = func(_ context.Context) (konnectivity.Tunnel, error) {
+		atomic.AddInt64(&tunnelCount, 1)
+		return newFakeTunnel(), nil
+	}
+
+	transport := s.getOrCreateTransport("cluster1")
+
+	// First pool miss: expect one tunnel.
+	conn, err := transport.DialContext(context.Background(), "tcp", "cluster1.proxy:7443")
+	if err != nil {
+		t.Fatalf("first DialContext: %v", err)
+	}
+	conn.Close()
+
+	if got := atomic.LoadInt64(&tunnelCount); got != 1 {
+		t.Errorf("after first pool miss: got %d tunnels, want 1", got)
+	}
+
+	// Second pool miss: expect a second tunnel (each tunnel is single-use).
+	conn2, err := transport.DialContext(context.Background(), "tcp", "cluster1.proxy:7443")
+	if err != nil {
+		t.Fatalf("second DialContext: %v", err)
+	}
+	conn2.Close()
+
+	if got := atomic.LoadInt64(&tunnelCount); got != 2 {
+		t.Errorf("after second pool miss: got %d tunnels, want 2", got)
+	}
+}
+
+func TestGetOrCreateTransport_TunnelNotCreatedOnCacheLookup(t *testing.T) {
+	// Verifies that merely looking up the cached transport does not call
+	// getTunnel -- tunnels are created lazily on DialContext (pool miss).
+	var tunnelCount int64
+	s := &userServer{}
+	s.getTunnel = func(_ context.Context) (konnectivity.Tunnel, error) {
+		atomic.AddInt64(&tunnelCount, 1)
+		return newFakeTunnel(), nil
+	}
+
+	// Two cache lookups -- no DialContext calls yet.
+	_ = s.getOrCreateTransport("cluster1")
+	_ = s.getOrCreateTransport("cluster1")
+
+	if got := atomic.LoadInt64(&tunnelCount); got != 0 {
+		t.Errorf("getTunnel must not be called during cache lookup, got %d calls", got)
+	}
+}
+
+// --- ServeHTTP upgrade-detection tests ---
+
+func TestServeHTTP_NonUpgradeUsesTransportCache(t *testing.T) {
+	// Verifies that non-upgrade requests use the cached transport (getTunnel is
+	// not called just from cache lookup -- only on a DialContext pool miss).
+	var tunnelCount int64
+	s := &userServer{}
+	s.getTunnel = func(_ context.Context) (konnectivity.Tunnel, error) {
+		atomic.AddInt64(&tunnelCount, 1)
+		return newFakeTunnel(), nil
+	}
+
+	// Seeding the cache must not trigger getTunnel.
+	preexisting := s.getOrCreateTransport("mycluster")
+	if atomic.LoadInt64(&tunnelCount) != 0 {
+		t.Fatal("getTunnel must not be called on cache seed")
+	}
+
+	// A second lookup must return the same transport.
+	if s.getOrCreateTransport("mycluster") != preexisting {
+		t.Error("second cache lookup returned a different transport")
+	}
+}
+
+func TestServeHTTP_UpgradeRequestBypassesTransportCache(t *testing.T) {
+	// Start a TLS backend that just returns 200.
+	backend := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(backend.Close)
+
+	rootCAs := backend.Client().Transport.(*http.Transport).TLSClientConfig.RootCAs
+	setupServiceProxyRootCA(t, rootCAs)
+
+	var tunnelCount int64
+	s := &userServer{}
+	s.getTunnel = func(ctx context.Context) (konnectivity.Tunnel, error) {
+		atomic.AddInt64(&tunnelCount, 1)
+		return newDialingFakeTunnel(backend.Listener.Addr().String()), nil
+	}
+
+	// Seed the cache for this cluster.
+	preexisting := s.getOrCreateTransport("mycluster")
+
+	// Send an upgrade request.
+	req := httptest.NewRequest(http.MethodGet,
+		"/mycluster/api/v1/namespaces/default/pods/pod/exec", nil)
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Upgrade", "SPDY/3.1")
+	rr := httptest.NewRecorder()
+
+	s.ServeHTTP(rr, req)
+
+	// getTunnel must have been called for the upgrade request (bypass path).
+	if got := atomic.LoadInt64(&tunnelCount); got == 0 {
+		t.Error("getTunnel must be called for upgrade requests")
+	}
+
+	// The cached transport must be unchanged.
+	if s.getOrCreateTransport("mycluster") != preexisting {
+		t.Error("upgrade request must not replace the cached transport")
+	}
+}
+
+func TestServeHTTP_DifferentClustersGetDifferentTransports(t *testing.T) {
+	s := &userServer{}
+	s.getTunnel = func(_ context.Context) (konnectivity.Tunnel, error) {
+		return newFakeTunnel(), nil
+	}
+
+	ta := s.getOrCreateTransport("cluster-a")
+	tb := s.getOrCreateTransport("cluster-b")
+
+	if ta == tb {
+		t.Error("different clusters must have different cached transports")
+	}
+	if s.getOrCreateTransport("cluster-a") != ta {
+		t.Error("second lookup for cluster-a must return the same transport")
+	}
+	if s.getOrCreateTransport("cluster-b") != tb {
+		t.Error("second lookup for cluster-b must return the same transport")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes ACM-40348: Cluster Proxy Addon Overloaded Causing UI Instability in Fleet Virtualization

## Problem

The user-server creates a new gRPC tunnel (full TCP+TLS+HTTP/2 negotiation) and a new `http.Transport` for every incoming HTTP request, regardless of whether an existing tunnel to the same cluster is idle. Under load this generates thousands of short-lived `Proxy()` handlers on the ANP proxy-server, causing lock contention on shared state and the following errors in proxy-server logs:

- `"Receive channel from agent/frontend is full"`
- `"Stream read from frontend cancelled"`
- `"could not get frontend client for closing"`

Confirmed across two customer environments (ACM-40348, ACM-34580).

## Fix

Cache one `http.Transport` per managed cluster. Go's `http.Transport` retains the underlying `net.Conn` (the konnectivity tunnel) in its idle pool after each request completes, so `DialContext` -- which creates a new gRPC tunnel -- is only called on a pool miss. Sequential requests to the same cluster reuse the idle connection and the existing `Proxy()` stream on the proxy-server.

SPDY/WebSocket upgrade requests (e.g. `kubectl exec` terminal sessions) bypass the cache and retain dedicated-tunnel-per-request behavior.

## Changes

- `pkg/userserver/user_server.go`: add `transports sync.Map` field, `getOrCreateTransport()` method, upgrade detection in `ServeHTTP`
- `pkg/userserver/user_server_test.go`: new test file with 9 unit tests covering transport caching, upgrade bypass, concurrent access, and cross-cluster isolation

## Notes

- This is a **draft PR for testing** against a downstream build in an ACM 2.16 environment
- The backport uses `k8s.io/apimachinery/pkg/util/httpstream` (available on this branch) instead of `k8s.io/streaming/pkg/httpstream` (only available on newer branches)
- The proper fix will be submitted upstream to `open-cluster-management-io/cluster-proxy` first, then cherry-picked to release branches through the normal process
- No changes to konnectivity client, ANP proxy-server, Helm charts, CRDs, or any other component

## Testing

- [ ] Unit tests pass: `go test ./pkg/...`
- [ ] Lint passes: `make lint`
- [ ] Before/after tunnel count comparison in ACM 2.16 environment with 2 managed clusters
- [ ] Upgrade request (kubectl exec / console terminal) still works